### PR TITLE
Fix null-ref when no osu token in db

### DIFF
--- a/src/services/osu-service.ts
+++ b/src/services/osu-service.ts
@@ -22,7 +22,7 @@ export class OsuService {
 
         try {
             const token = await Token.findOne({ _id: 1 }).exec();
-            if (token.isExpired() || !token || forceNew) {
+            if (!token || token.isExpired() || forceNew) {
                 const response = await axios.post('https://osu.ppy.sh/oauth/token', bodyParameters);
                 const newToken = new Token({
                     _id: 1,


### PR DESCRIPTION
i just swapped this around so that it checks if the token is null before checking if it's expired to avoid the nullref